### PR TITLE
ci: cloud flare 배포 기능 추가 close #5 

### DIFF
--- a/.github/workflows/pages-publish.yml
+++ b/.github/workflows/pages-publish.yml
@@ -1,0 +1,49 @@
+name: Deploy to Cloudflare Pages
+
+on:                 
+  push:
+  pull_request:
+
+concurrency:
+  group: deploy-pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - run: npm ci --prefer-offline --no-audit
+
+      # 브랜치 → 빌드 스크립트 매핑
+      - name: Pick build script
+        id: pick
+        shell: bash
+        run: |
+          case "$GITHUB_REF_NAME" in
+            production) CMD=build:prod ;;
+            main)       CMD=build:staging ;;
+            *)          CMD=build:dev ;;
+          esac
+          echo "cmd=$CMD" >> "$GITHUB_OUTPUT"
+
+      - run: npm run ${{ steps.pick.outputs.cmd }}
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken:  ${{ secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GH_TOKEN }}
+          command: pages deploy ./dist --project-name=nari-web

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:prod": "tsc -b && vite build --mode production",
+    "build:staging": "tsc -b && vite build --mode staging",
+    "build:dev": "tsc -b && vite build --mode dev",
     "lint": "eslint .",
     "preview": "vite preview"
   },


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## 연결된 이슈

<!--
  예시:
  - closes #123
  - fixes #456
-->

- close #5 

## 변경 내용

<!--
  * Issue에서 요청한 사항을 어떻게 해결했는지 간략히 요약합니다.
  * 주요 코드 변경점, 아키텍처/설정 수정 사항 등을 작성해주세요.
-->

1. github actions를 이용하여 빌드 하고 cloudflare의 pages에 전송 하는 기능을 추가하였어요 (CI 기능 도입)
- 브랜치 별 빌드와 배포는 다음과 같이 진행돼요 (배포 주소 연결은 cloudflare의 DNS 설정에서 해줬어요!)
    - production  branch-> `npm run build:prod`실행 하여 빌드 && https://www.nari-web.com 배포 
    - main branch -> `npm run build:staging` 실행 하여 빌드 && https://web-staging.nari-web.com 배포
    - 그 외 branch ->  `npm run build:dev` 실행 하여 빌드 && <브랜치명>.nari-web.pages.dev 혹은 <hash>.nari-web.pages.dev 배포

## 주의 사항

<!--
  배포 전/후에 확인해야 할 점, 마이그레이션 필요 여부, 기존 기능 영향 등
-->
- 현재 pr이 반영되면 push 또는 pr 이벤트가 발생할 때 github actions에서 자동으로 빌드할 수 있어요! 한 달 500회 까지 무료라서 가능 하다면 여러 커밋을 묶어서 push 해주시면 좋을 것 같아요!