### PR TITLE
ci: GitHub Secrets에 저장된 base64 인코딩된 값으로 빌드 전 .env 파일을 생성하도록 설정

### DIFF
--- a/.github/workflows/pages-publish.yml
+++ b/.github/workflows/pages-publish.yml
@@ -38,6 +38,23 @@ jobs:
           esac
           echo "cmd=$CMD" >> "$GITHUB_OUTPUT"
 
+      # GitHub Secrets에 저장된 base64 값을 .env.* 파일로 복원
+      - name: Generate .env file
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$GITHUB_REF_NAME" in
+            production)
+              echo "${{ secrets.ENV_PROD_B64 }}"    | base64 --decode > .env.prod
+              ;;
+            main)
+              echo "${{ secrets.ENV_STAGING_B64 }}" | base64 --decode > .env.staging
+              ;;
+            *)
+              echo "${{ secrets.ENV_DEV_B64 }}"     | base64 --decode > .env.dev
+              ;;
+          esac
+
       - run: npm run ${{ steps.pick.outputs.cmd }}
 
       - name: Deploy to Cloudflare Pages
@@ -47,3 +64,4 @@ jobs:
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           gitHubToken: ${{ secrets.GH_TOKEN }}
           command: pages deploy ./dist --project-name=nari-web
+          


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## 연결된 이슈

<!--
  예시:
  - closes #123
  - fixes #456
-->

- Close #21 

## 변경 내용

<!--
  * Issue에서 요청한 사항을 어떻게 해결했는지 간략히 요약합니다.
  * 주요 코드 변경점, 아키텍처/설정 수정 사항 등을 작성해주세요.
-->

1. GitHub Actions 워크플로우에 `.env` 파일을 생성하는 단계를 추가했어요
GitHub Secrets에 저장된 base64 인코딩된 문자열을 빌드 전에 복호화하여 `.env.dev`, `.env.staging`, `.env.prod` 파일로 생성하도록 구성했어요. 브랜치 이름(`production`, `main`, 기타)에 따라 자동으로 해당 환경 파일을 생성하고 `.env`로 복사되게 설정했어요

## 주의 사항

<!--
  배포 전/후에 확인해야 할 점, 마이그레이션 필요 여부, 기존 기능 영향 등
-->
- GitHub Secrets에 `ENV_DEV_B64`, `ENV_STAGING_B64`, `ENV_PROD_B64`가 base64 인코딩된 값으로 등록되어 있어야 해요 
