### PR TITLE
feat : 닉네임, 비밀번호 변경, 회원탈퇴 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
+        "@radix-ui/react-dialog": "^1.1.14",
         "@tailwindcss/vite": "^4.1.4",
         "@tanstack/react-query": "^5.74.4",
         "@use-funnel/react-router": "^0.0.4",
@@ -1038,6 +1039,320 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
+      "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA=="
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.14.tgz",
+      "integrity": "sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.10.tgz",
+      "integrity": "sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.2.tgz",
+      "integrity": "sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.4.tgz",
+      "integrity": "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.40.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.0.tgz",
@@ -1632,7 +1947,7 @@
       "version": "19.1.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
       "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1641,7 +1956,7 @@
       "version": "19.1.2",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.2.tgz",
       "integrity": "sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2162,6 +2477,17 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -2569,7 +2895,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -2694,6 +3020,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -3540,6 +3871,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -5042,6 +5381,51 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.0.tgz",
+      "integrity": "sha512-sGsQtcjMqdQyijAHytfGEELB8FufGbfXIsvUTe+NLx1GDRJCXtCFLBLUI1eyZCKXXvbEU2C6gai0PZKoIE9Vbg==",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-router": {
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.5.3.tgz",
@@ -5061,6 +5445,27 @@
       },
       "peerDependenciesMeta": {
         "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -5713,8 +6118,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "optional": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/turbo-stream": {
       "version": "2.4.0",
@@ -5930,6 +6334,47 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
+    "@radix-ui/react-dialog": "^1.1.14",
     "@tailwindcss/vite": "^4.1.4",
     "@tanstack/react-query": "^5.74.4",
     "@use-funnel/react-router": "^0.0.4",

--- a/src/app/router/PrivateRoute.tsx
+++ b/src/app/router/PrivateRoute.tsx
@@ -1,0 +1,13 @@
+import { Navigate, Outlet } from 'react-router';
+
+const PrivateRoute = () => {
+  const token = localStorage.getItem('accessToken');
+
+  if (!token) {
+    return <Navigate to="/signin" replace />;
+  }
+
+  return <Outlet />;
+};
+
+export default PrivateRoute;

--- a/src/app/router/index.tsx
+++ b/src/app/router/index.tsx
@@ -1,5 +1,7 @@
 import { createBrowserRouter } from 'react-router';
+import PrivateRoute from '@/app/router/PrivateRoute';
 import Home from '@/pages/Home';
+import My from '@/pages/My';
 import Signin from '@/pages/Signin';
 import Signup from '@/pages/Signup';
 
@@ -15,5 +17,14 @@ export const router = createBrowserRouter([
   {
     path: '/signin',
     element: <Signin />,
-  }
+  },
+  {
+    element: <PrivateRoute />,
+    children: [
+      {
+        path: '/my',
+        element: <My />,
+      },
+    ],
+  },
 ]);

--- a/src/features/auth/validation/schema.ts
+++ b/src/features/auth/validation/schema.ts
@@ -8,25 +8,29 @@ export const baseSignupSchema = z.object({
   nickname: z.string(),
 });
 
+export const nicknameField = z
+  .string()
+  .min(1, { message: '닉네임을 입력해주세요.' })
+  .max(20, { message: '닉네임은 20자 이하로 입력해주세요.' });
+
+export const passwordField = z
+  .string()
+  .min(8, { message: '비밀번호는 8자 이상이어야 합니다.' })
+  .max(50, { message: '비밀번호는 50자 이하이어야 합니다.' })
+  .regex(/[0-9]/, { message: '비밀번호에 숫자가 포함되어야 합니다.' })
+  .regex(/[a-zA-Z]/, { message: '비밀번호에 영문자가 포함되어야 합니다.' })
+  .regex(/[!@#$%^&*()]/, {
+    message: '비밀번호에 특수문자(!@#$%^&*())가 포함되어야 합니다.',
+  })
+  .regex(/^[0-9a-zA-Z!@#$%^&*()]+$/, {
+    message: '허용되지 않은 문자가 포함되어 있습니다.',
+  });
+
 export const signupSchema = baseSignupSchema
   .extend({
     email: z.string().email('올바른 이메일을 입력해주세요.'),
-    password: z
-      .string()
-      .min(8, { message: '비밀번호는 8자 이상이어야 합니다.' })
-      .max(50, { message: '비밀번호는 50자 이하이어야 합니다.' })
-      .regex(/[0-9]/, { message: '비밀번호에 숫자가 포함되어야 합니다.' })
-      .regex(/[a-zA-Z]/, { message: '비밀번호에 영문자가 포함되어야 합니다.' })
-      .regex(/[!@#$%^&*()]/, {
-        message: '비밀번호에 특수문자(!@#$%^&*())가 포함되어야 합니다.',
-      })
-      .regex(/^[0-9a-zA-Z!@#$%^&*()]+$/, {
-        message: '허용되지 않은 문자가 포함되어 있습니다.',
-      }),
-    nickname: z
-      .string()
-      .min(1, { message: '닉네임을 입력해주세요.' })
-      .max(20, { message: '닉네임은 20자 이하로 입력해주세요.' }),
+    password: passwordField,
+    nickname: nicknameField,
   })
   .refine((data) => data.password === data.passwordConfirm, {
     path: ['passwordConfirm'],

--- a/src/features/my/apis/index.ts
+++ b/src/features/my/apis/index.ts
@@ -1,0 +1,31 @@
+import {
+  PatchNicknameRequest,
+  PatchPasswordRequest,
+} from '@/features/my/apis/types';
+import { httpClient } from '@/shared/libs/httpClient';
+
+const BASE_URL = 'user/me';
+
+const myApi = {
+  patchPassword: async ({ oldPassword, newPassword }: PatchPasswordRequest) => {
+    const url = `${BASE_URL}/password`;
+    const body = {
+      oldPassword,
+      newPassword,
+    };
+    return await httpClient.patch(url, body);
+  },
+  patchNickname: async ({ newNickname }: PatchNicknameRequest) => {
+    const url = `${BASE_URL}/nickname`;
+    const body = {
+      newNickname,
+    };
+    return await httpClient.patch(url, body);
+  },
+  deleteWithdrawal: async () => {
+    const url = `${BASE_URL}/withdrawal`;
+    return await httpClient.delete(url);
+  },
+};
+
+export default myApi;

--- a/src/features/my/apis/types.ts
+++ b/src/features/my/apis/types.ts
@@ -1,0 +1,8 @@
+export type PatchPasswordRequest = {
+  oldPassword: string;
+  newPassword: string;
+};
+
+export type PatchNicknameRequest = {
+  newNickname: string;
+};

--- a/src/features/my/components/NicknameChangeModal.tsx
+++ b/src/features/my/components/NicknameChangeModal.tsx
@@ -1,0 +1,62 @@
+import { Dispatch, SetStateAction } from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as RadixDialog from '@radix-ui/react-dialog';
+import { z } from 'zod';
+import { nicknameField } from '@/features/auth/validation/schema';
+import useChangeNicknameMutation from '@/features/my/hooks/useChangeNicknameMutation';
+import { Form } from '@/shared/components/form';
+
+type NicknameChangeModalProps = {
+  open: boolean;
+  onOpenChange: Dispatch<SetStateAction<boolean>>;
+};
+
+const NicknameChangeModal = ({
+  open,
+  onOpenChange,
+}: NicknameChangeModalProps) => {
+  const { handleSubmit, control } = useForm({
+    resolver: zodResolver(z.object({ newNickname: nicknameField })),
+    mode: 'onChange',
+  });
+  const { mutate: changeNicknameMutate } = useChangeNicknameMutation();
+
+  const onSubmit: SubmitHandler<{ newNickname: string }> = (data) => {
+    changeNicknameMutate(data);
+  };
+
+  return (
+    <RadixDialog.Root modal open={open} onOpenChange={onOpenChange}>
+      <RadixDialog.Portal>
+        <RadixDialog.Content className="fixed inset-0  bg-white">
+          <RadixDialog.Title>닉네임 변경</RadixDialog.Title>
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            className="flex flex-col items-start"
+          >
+            <Form.Field
+              control={control}
+              name="newNickname"
+              render={({ field, formState }) => (
+                <>
+                  <Form.Control
+                    field={field}
+                    placeholder="새로운 닉네임을 입력해주세요"
+                  />
+                  <Form.ErrorMessage
+                    errorMessage={formState.errors.newNickname?.message}
+                  />
+                </>
+              )}
+            />
+            <input type="submit" />
+          </form>
+        </RadixDialog.Content>
+        <RadixDialog.Close />
+      </RadixDialog.Portal>
+    </RadixDialog.Root>
+  );
+};
+
+export default NicknameChangeModal;

--- a/src/features/my/components/PasswordChangeModal.tsx
+++ b/src/features/my/components/PasswordChangeModal.tsx
@@ -1,0 +1,88 @@
+import { Dispatch, SetStateAction } from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as RadixDialog from '@radix-ui/react-dialog';
+import { z } from 'zod';
+import { passwordField } from '@/features/auth/validation/schema';
+import useChangePasswordMutation from '@/features/my/hooks/useChangePasswordMutation';
+import { Form } from '@/shared/components/form';
+
+type PasswordChangeModalProps = {
+  open: boolean;
+  onOpenChange: Dispatch<SetStateAction<boolean>>;
+};
+
+const PasswordChangeModal = ({
+  open,
+  onOpenChange,
+}: PasswordChangeModalProps) => {
+  const { handleSubmit, control } = useForm({
+    resolver: zodResolver(
+      z.object({ oldPassword: passwordField, newPassword: passwordField }),
+    ),
+    mode: 'onChange',
+  });
+  const { mutate: changePasswordMutate } = useChangePasswordMutation();
+
+  const onSubmit: SubmitHandler<{
+    oldPassword: string;
+    newPassword: string;
+  }> = (data) => {
+    changePasswordMutate(data);
+  };
+
+  return (
+    <RadixDialog.Root modal open={open} onOpenChange={onOpenChange}>
+      <RadixDialog.Portal>
+        <RadixDialog.Content className="fixed inset-0  bg-white">
+          <RadixDialog.Title>비밀번호 변경</RadixDialog.Title>
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            className="flex flex-col items-start"
+          >
+            <Form.Field
+              control={control}
+              name="oldPassword"
+              render={({ field, formState }) => {
+                return (
+                  <>
+                    <Form.Control
+                      field={field}
+                      placeholder="기존 비밀번호를 입력해주세요"
+                      type="password"
+                    />
+                    <Form.ErrorMessage
+                      errorMessage={formState.errors.oldPassword?.message}
+                    />
+                  </>
+                );
+              }}
+            />
+            <Form.Field
+              control={control}
+              name="newPassword"
+              render={({ field, formState }) => {
+                return (
+                  <>
+                    <Form.Control
+                      field={field}
+                      placeholder="새로운 비밀번호를 입력해주세요"
+                      type="password"
+                    />
+                    <Form.ErrorMessage
+                      errorMessage={formState.errors.newPassword?.message}
+                    />
+                  </>
+                );
+              }}
+            />
+            <input type="submit" />
+          </form>
+        </RadixDialog.Content>
+        <RadixDialog.Close />
+      </RadixDialog.Portal>
+    </RadixDialog.Root>
+  );
+};
+
+export default PasswordChangeModal;

--- a/src/features/my/hooks/useChangeNicknameMutation.ts
+++ b/src/features/my/hooks/useChangeNicknameMutation.ts
@@ -1,0 +1,14 @@
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import myApi from '@/features/my/apis';
+
+const useChangeNicknameMutation = () => {
+  return useMutation({
+    mutationFn: myApi.patchNickname,
+    onError: ({ data }) => {
+      toast.error(data.error.message);
+    },
+  });
+};
+
+export default useChangeNicknameMutation;

--- a/src/features/my/hooks/useChangePasswordMutation.ts
+++ b/src/features/my/hooks/useChangePasswordMutation.ts
@@ -1,0 +1,14 @@
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import myApi from '@/features/my/apis';
+
+const useChangePasswordMutation = () => {
+  return useMutation({
+    mutationFn: myApi.patchPassword,
+    onError: ({ data }) => {
+      toast.error(data.error.message);
+    },
+  });
+};
+
+export default useChangePasswordMutation;

--- a/src/features/my/hooks/useDeleteAccountMutation.ts
+++ b/src/features/my/hooks/useDeleteAccountMutation.ts
@@ -1,0 +1,18 @@
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import myApi from '@/features/my/apis';
+import { accessTokenStorage } from '@/shared/utils';
+
+const useDeleteAccountMutation = () => {
+  return useMutation({
+    mutationFn: myApi.deleteWithdrawal,
+    onSuccess: () => {
+      accessTokenStorage.removeToken();
+    },
+    onError: ({ data }) => {
+      toast.error(data.error.message);
+    },
+  });
+};
+
+export default useDeleteAccountMutation;

--- a/src/pages/My.tsx
+++ b/src/pages/My.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import NicknameChangeModal from '@/features/my/components/NicknameChangeModal';
+import PasswordChangeModal from '@/features/my/components/PasswordChangeModal';
+import useDeleteAccountMutation from '@/features/my/hooks/useDeleteAccountMutation';
+import Button from '@/shared/components/Button';
+import Dialog from '@/shared/components/Dialog';
+
+const My = () => {
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [isChangeNicknameOpen, setIsChangeNicknameOpen] = useState(false);
+  const [isChangePasswordOpen, setIsChangePasswordOpen] = useState(false);
+  const { mutate: deleteAccountMutate } = useDeleteAccountMutation();
+
+  return (
+    <>
+      <Button onClick={() => setIsChangePasswordOpen(true)}>
+        비밀번호 변경
+      </Button>
+      <Button onClick={() => setIsChangeNicknameOpen(true)}>닉네임 수정</Button>
+      <Button onClick={() => setIsDeleteOpen(true)}>회원 탈퇴</Button>
+      <Dialog
+        description="정말로 탈퇴하시겠습니까?"
+        open={isDeleteOpen}
+        onOpenChange={setIsDeleteOpen}
+        onLeftButtonClick={() => {
+          deleteAccountMutate();
+        }}
+      />
+      <NicknameChangeModal
+        open={isChangeNicknameOpen}
+        onOpenChange={setIsChangeNicknameOpen}
+      />
+      <PasswordChangeModal
+        open={isChangePasswordOpen}
+        onOpenChange={setIsChangePasswordOpen}
+      />
+    </>
+  );
+};
+
+export default My;

--- a/src/shared/components/Dialog.tsx
+++ b/src/shared/components/Dialog.tsx
@@ -1,0 +1,42 @@
+import { Dispatch, SetStateAction } from 'react';
+import * as RadixDialog from '@radix-ui/react-dialog';
+import Button from '@/shared/components/Button';
+
+interface DialogProps {
+  title?: string;
+  description?: string;
+  open: boolean;
+  onOpenChange: Dispatch<SetStateAction<boolean>>;
+  onLeftButtonClick?: () => void;
+}
+
+const Dialog = ({
+  title,
+  description,
+  open,
+  onOpenChange,
+  onLeftButtonClick,
+}: DialogProps) => {
+  return (
+    <RadixDialog.Root open={open} onOpenChange={onOpenChange}>
+      <RadixDialog.Portal>
+        <RadixDialog.Overlay className="fixed inset-0 bg-black/40" />
+        <RadixDialog.Content className="fixed left-1/2 top-1/2 max-h-[85vh] w-[90vw] max-w-[500px] -translate-x-1/2 -translate-y-1/2 rounded-md bg-white p-[25px]">
+          <RadixDialog.Title>{title}</RadixDialog.Title>
+          <RadixDialog.Description>{description}</RadixDialog.Description>
+          <Button onClick={onLeftButtonClick}>확인</Button>
+          <Button
+            onClick={() => {
+              onOpenChange(false);
+            }}
+          >
+            취소
+          </Button>
+        </RadixDialog.Content>
+        <RadixDialog.Close />
+      </RadixDialog.Portal>
+    </RadixDialog.Root>
+  );
+};
+
+export default Dialog;

--- a/src/shared/libs/httpClient/index.ts
+++ b/src/shared/libs/httpClient/index.ts
@@ -6,6 +6,15 @@ const axiosInstance = axios.create({
 
 export const httpClient = axiosInstance;
 
+httpClient.interceptors.request.use((config) => {
+  const token = localStorage.getItem('accessToken');
+
+  if (token) {
+    config.headers['Authorization'] = `Bearer ${token}`;
+  }
+  return config;
+});
+
 httpClient.interceptors.response.use(
   (response) => response.data,
   (error: AxiosError) => {


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## 연결된 이슈

- #16 #17 #18 

## 변경 내용

1. PrivateRoute 컴포넌트를 구현하여 인증 기반 라우팅 제어 추가
   └ 현재는 `/my` 페이지에 한해 로그인된 사용자만 접근 가능하도록 설정
2. `@radix-ui/react-dialog`를 사용해 모달 및 다이얼로그 UI 컴포넌트 구현

## 주의 사항

- Radix UI의 Dialog 컴포넌트가 모바일 WebView 환경에서도 안정적으로 작동하는지 확인 필요
